### PR TITLE
Don't include merge commits when checking for issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,6 @@ steps:
 
 ## Inputs
 
+`host` - issue tracker URL
+`token` - access token to issue tracker
 `type` - type of issue tracker - default - `jira`

--- a/git-commands.js
+++ b/git-commands.js
@@ -8,7 +8,7 @@ module.exports = {
   getCommitMessages: () => {
     try {
       const defaultBranchName = String(exec('git remote show origin | grep "HEAD branch" | cut -d" " -f5')).trim();
-      return String(exec(`git rev-list --format=%B${COMMIT_SEPARATOR} HEAD ^origin/${defaultBranchName}`))
+      return String(exec(`git rev-list --no-merges --format=%B${COMMIT_SEPARATOR} HEAD ^origin/${defaultBranchName}`))
         .trim()
         .replace(/\n/g, ' ')
         .split(new RegExp(COMMIT_SEPARATOR))

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "@actions/github": "^5.0.0",
     "node-fetch": "^2.6.1"
   },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "lint": "eslint .",
     "build": "ncc build index.js -o dist --source-map --license licenses.txt",


### PR DESCRIPTION
# What
Include only regular commits when checking for valid issues.
Fixes #21

# Why
Github generated merge commits may lack issues and these aren't further checked anyway.
